### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /hubo-default
 /hubo-console
 /hubo-loop
-/src/*.o
+*.o
 /*.log
 /Makefile.in
 /Makefile
@@ -41,3 +41,9 @@ hubo-ach-*.tar.gz
 /debian/hubo-ach-utils.debhelper.log
 /debian/hubo-ach-utils.substvars
 /debian/files
+/libhuboparams.la
+/hubo-jointparams.lo
+/debian/hubo-ach
+.libs
+/debian/hubo-ach.debhelper.log
+/debian/hubo-ach.substvars

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
+*.o
+*.log
+*.Po
 /hubo-main
 /hubo-default
 /hubo-console
 /hubo-loop
-*.o
-/*.log
 /Makefile.in
 /Makefile
 /aclocal.m4
@@ -12,7 +13,6 @@
 /config.guess
 /config.h
 /config.h.in
-/config.log
 /config.status
 /config.sub
 /configure
@@ -23,7 +23,6 @@
 /ltmain.sh
 /missing
 /stamp-h1
-*.Po
 hubo-ach-*.tar.gz
 /m4/libtool.m4
 /m4/ltoptions.m4
@@ -36,9 +35,7 @@ hubo-ach-*.tar.gz
 /debian/tmp
 /debian/hubo-ach-utils
 /debian/hubo-ach-dev
-/debian/hubo-ach-dev.debhelper.log
 /debian/hubo-ach-dev.substvars
-/debian/hubo-ach-utils.debhelper.log
 /debian/hubo-ach-utils.substvars
 /debian/files
 /libhuboparams.la


### PR DESCRIPTION
Clean up and update the gitignore file
- Change src/_.o and /_.log to just plain *.o and *.log so we can remove some redundant targeted ignores
- Add various setup and compilation products, such as the .la file and the debian packaging temp area
- Add logs from the debian packaging process

Resubmitting this so that it doesn't have my debian fixes mixed in with it. Sorry for cluttering up the pull request list.
