### PR TITLE
extern "C" when hubo-ach is used in C++ projects.

### DIFF
--- a/include/hubo-daemon.h
+++ b/include/hubo-daemon.h
@@ -8,6 +8,9 @@
 */
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 
 int hubo_sig_quit;
@@ -17,3 +20,7 @@ int hubo_sig_usr2;
 void hubo_daemonize();
 void hubo_daemon_close();
 void hubo_assert( int result, int line ); // Instructs the program to quit gracefully if the result is not true
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/hubo-daemonID.h
+++ b/include/hubo-daemonID.h
@@ -14,6 +14,11 @@
 #define HUBO_DAEMONID_H
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 /* D_ = Daemon-related parameter */
 // hubo_d_cmd_t are used to specify board commands being sent to the hubo daemon
 //	They should be placed hubo_board_cmd_t.
@@ -385,7 +390,9 @@ typedef enum {
 
 
 
-
+#ifdef __cplusplus
+}
+#endif
 
 
 

--- a/include/hubo-jointparams.h
+++ b/include/hubo-jointparams.h
@@ -1,6 +1,10 @@
 #ifndef JOINT_PARAM_PARSE_H
 #define JOINT_PARAM_PARSE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // sets all the joint parameters for Hubo in a 
 // hubo_param struct which is define  hubo.h. See ./include/hubo.h
 int setJointParams(struct hubo_param *H_param, struct hubo_state *H_state);
@@ -13,5 +17,9 @@ void setPosZeros();
 // sets all the hubo_board_cmd struct member values to zero.
 // See ./include/hubo.h 
 void setConsoleFlags();
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif //ifndef JOINT_PARAM_PARSE_H

--- a/include/hubo.h
+++ b/include/hubo.h
@@ -3,6 +3,11 @@
 #define HUBO_PRIMARY_H
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 // for Hubo
 #include "hubo-daemonID.h"
 
@@ -262,6 +267,13 @@ struct hubo_board_cmd {
 
 
 extern int hubo_debug;
+
+
+#ifdef __cplusplus
+}
+#endif
+
+
 
 #endif //HUBO_PRIMARY_H
 

--- a/include/hubo/canID.h
+++ b/include/hubo/canID.h
@@ -2,6 +2,10 @@
 #ifndef CAN_ID_H
 #define CAN_ID_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define		LOWER_CAN		0
 #define		UPPER_CAN		1
 
@@ -448,5 +452,8 @@
 // Error status stuff
 #define H_HOME_SUCCESS      0x06
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/hubo/hubo-esdcan.h
+++ b/include/hubo/hubo-esdcan.h
@@ -2,6 +2,10 @@
 #ifndef HUBO_ESDCAN_H
 #define HUBO_ESDCAN_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <ntcan.h>
 
 typedef NTCAN_HANDLE hubo_can_t ;
@@ -11,5 +15,9 @@ extern hubo_can_t hubo_socket[4];
 int sendCan(hubo_can_t, struct can_frame *f);
 void openAllCAN(int vCan);
 int readCan(hubo_can_t skt, struct can_frame *f, double timeoD);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif //HUBO_ESDCAN_H

--- a/include/hubo/hubo-socketcan.h
+++ b/include/hubo/hubo-socketcan.h
@@ -2,6 +2,10 @@
 #ifndef HUBO_SOCKETCAN_H
 #define HUBO_SOCKETCAN_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef int hubo_can_t ;
 
 extern hubo_can_t hubo_socket[4];
@@ -9,5 +13,9 @@ extern hubo_can_t hubo_socket[4];
 int sendCan(hubo_can_t, struct can_frame *f);
 void openAllCAN(int vCan);
 int readCan(hubo_can_t skt, struct can_frame *f, double timeoD);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif //HUBO_SOCKETCAN_H


### PR DESCRIPTION
This allows c++ projects to use functions from hubo-ach. Up until now c++ projects would only have been able to use data structures, variables, and definitions, but c++ function name mangling would prevent them from using functions. This patch fixes that by adding the standard "#ifdef __cplusplus extern C" language to all header files.
