### PR TITLE
Fix Makefile.am breakage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,13 +3,9 @@ AM_CPPFLAGS = -I$(top_srcdir)/include
 
 EXTRA_DIST = joint.table sensor.table scripts/hubo-ach
 
-#huboscriptdir = $(sysconfdir)/bin
-huboscriptdir = /usr/bin
-#init_ddir = $(sysconfdir)/init.d
-init_ddir = $(huboscriptdir)
-init_d_SCRIPTS = scripts/hubo-ach 
+init_ddir = $(sysconfdir)/init.d
+init_d_SCRIPTS = scripts/hubo-ach
 
-# installed under $prefix/include/
 include_HEADERS = include/hubo.h include/hubo-jointparams.h include/hubo-daemonID.h
 #include_HEADERS = include/hubo.h
 
@@ -18,19 +14,17 @@ include_HEADERS = include/hubo.h include/hubo-jointparams.h include/hubo-daemonI
 #otherinclude_HEADERS = 	                \
 #	include/hubo/hubo-esdcan.h      \
 #	include/hubo/hubo-socketcan.h   \
-#	include/hubo/canID.h            
+#	include/hubo/canID.h
 
 # not installed
 
-huboachconfdir=/etc/hubo-ach
+huboachconfdir=$(sysconfdir)/hubo-ach
 
 huboachconf_DATA = tables/joint.table tables/sensor.table
 
-#hubo_jointparamsdir = $(prefix)/lib
-hubo_jointparamsdir = /usr/lib
-hubo_jointparams_LTLIBRARIES = libhuboparams.la
+lib_LTLIBRARIES = libhuboparams.la
+
 libhuboparams_la_SOURCES = src/hubo-jointparams.c
-libhuboparams_la_LDFLAGS = -module -avoid-version -shared
 
 bin_PROGRAMS = hubo-daemon hubo-console hubo-read
 


### PR DESCRIPTION
- Quash warning "Linking the executable hubo-read against the loadable module libhuboparams.so is not portable!"  I assume making libhuboparams.so a loadable module was unintentional.  Otherwise, one should probably link with dlopen() or equivalent.
- Install everything under $prefix.  It's better to put things where the user asks, rather than dropping various files under / and /usr.
- SysV init scripts go under etc/init.d, not bin.  Perhaps a symlink under bin would be reasonable.
