### PR TITLE
added joint names to hubo.h and removed them from jointparams.c

### DIFF
--- a/include/hubo.h
+++ b/include/hubo.h
@@ -129,6 +129,16 @@ extern "C" {
 				   guaranteed safe to access without
 				   faulting */
 
+// array of joint name strings (total of 42)
+static const char *jointNames[HUBO_JOINT_COUNT] =
+	{"WST", "NKY", "NK1", "NK2", // 0 1 2 3
+	 "LSP", "LSR", "LSY", "LEB", "LWY", "LWR", "LWP", // 4 5 6 7 8 9 10
+	 "RSP", "RSR", "RSY", "REB", "RWY", "RWR", "RWP", "N/A", // 11 12 13 14 15 16 17 18
+	 "LHY", "LHR", "LHP", "LKN", "LAP", "LAR", "N/A", // 19 20 21 22 23 24 25
+	 "RHY", "RHR", "RHP", "RKN", "RAP", "RAR", // 26 27 28 29 30 31
+	 "RF1", "RF2", "RF3", "RF4", "RF5", // 32 33 34 35 36
+	 "LF1", "LF2", "LF3", "LF4", "LF5"}; // 37 38 39 40 41
+
 typedef enum {
     HUBO_VIRTUAL_MODE_NONE        = 0, ///< not virtual mode
     HUBO_VIRTUAL_MODE_VIRTUAL     = 1, ///< virtual mode just uses vcan

--- a/src/hubo-jointparams.c
+++ b/src/hubo-jointparams.c
@@ -155,26 +155,6 @@ int setJointParams(hubo_param_t *H_param, struct hubo_state *H_state) {
 		}
 	}
 
-	// array of joint name values from header file hubo.h
-	uint16_t jointNameValues[] =
-			{WST, NKY, NK1, NK2,
-			LSP, LSR, LSY, LEB, LWY, LWR, LWP,
-			RSP, RSR, RSY, REB, RWY, RWR, RWP,
-			LHY, LHR, LHP, LKN, LAP, LAR,
-			RHY, RHR, RHP, RKN, RAP, RAR,
-			RF1, RF2, RF3, RF4, RF5,
-			LF1, LF2, LF3, LF4, LF5};
-
-	// array of joint name strings (total of 40)
-	char *jointNameStrings[] =
-			{"WST", "NKY", "NK1", "NK2",
-			 "LSP", "LSR", "LSY", "LEB", "LWY", "LWR", "LWP",
-			 "RSP", "RSR", "RSY", "REB", "RWY", "RWR", "RWP",
-			 "LHY", "LHR", "LHP", "LKN", "LAP", "LAR",
-			 "RHY", "RHR", "RHP", "RKN", "RAP", "RAR",
-			 "RF1", "RF2", "RF3", "RF4", "RF5",
-			 "LF1", "LF2", "LF3", "LF4", "LF5"};
-
 	// array of jmc name values from header file canId.h
 	uint8_t jmcNumbers[] = {JMC0, JMC1, JMC2, JMC3, JMC4, JMC5,
 				JMC6, JMC7, JMC8, JMC9, JMC10, JMC11,
@@ -226,10 +206,10 @@ int setJointParams(hubo_param_t *H_param, struct hubo_state *H_state) {
 		{
 
 			// check to make sure jointName is valid
-			size_t x;
-			for (x = 0; x < sizeof(jointNameStrings)/sizeof(jointNameStrings[0]); x++) {
-				if (0 == strcmp(tp.name, jointNameStrings[x])) {
-					i = jointNameValues[x];
+			size_t jntIndex;
+			for (jntIndex = 0; jntIndex < HUBO_JOINT_COUNT; jntIndex++) {
+				if (0 == strcmp(tp.name, jointNames[jntIndex])) {
+					i = jntIndex;
 					jntNameCount = 1;
 					break;
 				}


### PR DESCRIPTION
Moved the char\* array of joint names (jointNames) from hubo-jointparams.c to hubo.h and removed the jointNameValues array in hubo-jointparams.c because it is now redundant as well.
This was done so that the joint names can easily be accessed via their #DEFINE indices for such uses as error reporting to the user. Specifically, a print out of which joints did not home properly was added to tech-console, so that the user doesn't have to type "sudo service hubo-motion log" to find out which joints weren't homed, and even then it only displays the index number, which requires looking up.
