### PR TITLE
Fixed format specifiers for F/T values, which were breaking the readings

### DIFF
--- a/src/hubo-console.cpp
+++ b/src/hubo-console.cpp
@@ -329,7 +329,7 @@ int main() {
             H_cmd.type = D_GET_STATUS;
             H_cmd.joint = name2mot(getArg(buf,1),&H_param);  // set motor num
             r = ach_put( &chan_hubo_board_cmd, &H_cmd, sizeof(H_cmd) );
-            printf("%s - Getting Status \n", &H_param.joint[H_cmd.joint].name);
+            printf("%s - Getting Status \n", H_param.joint[H_cmd.joint].name);
             usleep(50*1000);
             hubo_update(&H_ref, &H_state);
             hubo_joint_status_t e = H_state.status[H_cmd.joint];
@@ -355,7 +355,7 @@ int main() {
           for( int i = 0; i < HUBO_JOINT_COUNT; i++) {
             hubo_joint_status_t e = H_state.status[i];
             printf("%s - %d %d %d %d %d %d %d %d %d %d %d %d %d %d \n"
-            , &H_param.joint[i].name
+            , H_param.joint[i].name
             , H_ref.mode[i]
             , H_state.joint[i].zeroed
             , e.homeFlag
@@ -375,7 +375,7 @@ int main() {
         else if (strcmp(buf0,"resetAll")==0) {
             for( int i = 0; i < HUBO_JOINT_COUNT; i++) {
                 hubo_enc_reset(&H_param, &H_cmd, i);
-                printf("%s - Resetting Encoder \n", &H_param.joint[i].name);
+                printf("%s - Resetting Encoder \n", H_param.joint[i].name);
                 usleep(10*1000);
             }
 	}

--- a/src/hubo-jointparams.c
+++ b/src/hubo-jointparams.c
@@ -83,7 +83,7 @@ int setSensorDefaults( hubo_param_t *h ) {
 
 		// read in the buffered line from fgets, matching the following pattern
 		// to get all the parameters for the joint on this line.
-		if (NUM_OF_SENSOR_PARAMETERS == sscanf(buff, "%s%hu%hhu%hu%hhd%hhd%hhd",
+		if (NUM_OF_SENSOR_PARAMETERS == sscanf(buff, "%s%hu%hhu%hu%hd%hd%hd",
 			tp.name,
 			&tp.can,
 			&tp.active,
@@ -553,7 +553,7 @@ int setJointParams(hubo_param_t *H_param, struct hubo_state *H_state, hubo_pwm_g
 
 		// read in the buffered line from fgets, matching the following pattern
 		// to get all the parameters for the joint on this line.
-		if (NUM_OF_JOINT_PARAMETERS == sscanf(buff, "%s%hu%u%hu%hu%hu%hu%hhd%s%hhu%hhu%hhu%lf%lf%hhu%hhu",
+		if (NUM_OF_JOINT_PARAMETERS == sscanf(buff, "%s%hu%u%hu%hu%hu%hu%hd%s%hhu%hhu%hhu%lf%lf%hhu%hhu",
 			tp.name,
 			&tp.motNo,
 			&tp.refEnc,


### PR DESCRIPTION
There was a fix for the simulator which changed int8_t to int16_t, but the format specifiers for these were not changed elsewhere in the code. This caused F/T readings to overflow.

I changed the format specifiers in hubo-jointparams.c

Fixed printf in hubo-console.
